### PR TITLE
Implemented Flask web app for serving HuggingFace Vision Transformers

### DIFF
--- a/app_flax_vit.py
+++ b/app_flax_vit.py
@@ -1,0 +1,30 @@
+#! /usr/bin/env python
+import os
+import io
+from flask import Flask, render_template, request
+from model_flax_vit import load_saved_model
+from PIL import Image
+
+HF_VIT_MODEL_NAME = os.environ.get("HF_VIT_MODEL_NAME", "google/vit-base-patch16-224")
+
+app = Flask(__name__)
+pipeline = load_saved_model(HF_VIT_MODEL_NAME)
+
+
+@app.route("/", methods=["GET"])
+def index():
+    return render_template("index.html")
+
+
+@app.route("/eval", methods=["POST"])
+def eval():
+    image = Image.open(io.BytesIO(request.data)).convert("L")
+    _, label_text = pipeline.predict(image)
+
+    # Dictionary return values are implicitly converted to JSON,
+    # which the client can parse to get the result.
+    return {"result": label_text}
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0")

--- a/model_flax_vit.py
+++ b/model_flax_vit.py
@@ -25,10 +25,11 @@ class ViTPipeline:
     def __init__(self, hugging_face_model_name: str) -> None:
         devices = np.array(jax.devices())  # (num_devices,)
 
-        # Defaults to a batch size (data parallelism, dp) of 1.
-        # (model parallelism axis, data parallelism axi/s).
+        # Defaults to a batch size of 1. (No data parallelism.)
         # Model is parallelized across all accelerator devices.
         self.device_mesh = devices.reshape((-1, 1))  # (num_devices, 1)
+
+        # Device mesh: (model parallelism axis, data parallelism axis).
         self.mesh_context = maps.Mesh(self.device_mesh, ("mp", "dp"))
 
         self.feature_extractor = ViTFeatureExtractor.from_pretrained(

--- a/model_flax_vit.py
+++ b/model_flax_vit.py
@@ -1,0 +1,87 @@
+from typing import TYPE_CHECKING, Tuple
+
+import numpy as np
+
+import jax
+from jax.experimental import maps, pjit, PartitionSpec
+
+from transformers import ViTFeatureExtractor, FlaxViTForImageClassification
+from PIL import Image
+from rich.progress import Progress, TimeElapsedColumn
+
+if TYPE_CHECKING:
+    from transformers.modeling_flax_outputs import FlaxSequenceClassifierOutput
+
+TEXT_LABEL = str
+
+
+class ViTPipeline:
+    """
+    ViT pipeline with pjit.
+    Initializing the class will initialize and activate
+    the JAX mesh.
+    """
+
+    def __init__(self, hugging_face_model_name: str) -> None:
+        devices = np.array(jax.devices())  # (num_devices,)
+
+        # Defaults to a batch size (data parallelism, dp) of 1.
+        # (model parallelism axis, data parallelism axi/s).
+        # Model is parallelized across all accelerator devices.
+        self.device_mesh = devices.reshape((-1, 1))  # (num_devices, 1)
+        self.mesh_context = maps.Mesh(self.device_mesh, ("mp", "dp"))
+
+        self.feature_extractor = ViTFeatureExtractor.from_pretrained(
+            hugging_face_model_name
+        )
+        (
+            self.model,
+            self.model_params,
+        ) = FlaxViTForImageClassification.from_pretrained(  # type: ignore
+            hugging_face_model_name,
+            dtype=jax.numpy.float16,  # type: ignore
+            _do_init=False,
+        )
+        self.pjit_model_fn = pjit.pjit(
+            self.model.__call__,
+            # Replicate input image, model params, and output labels.
+            # Exact ops placement is up to pjit.
+            # Adjust in_axis_resources to support larger models.
+            in_axis_resources=PartitionSpec(),
+            out_axis_resources=PartitionSpec(),
+        )
+        self.labels = self.model.config.id2label
+        if self.labels is None:
+            self.labels = {}
+
+    def predict(self, image: Image.Image) -> Tuple[int, TEXT_LABEL]:
+        """
+        Run pipeline on the given image and return integer label.
+        """
+        self.mesh_context.__enter__()
+        rgb_image = image.convert("RGB")
+        pixel_values = self.feature_extractor(rgb_image)["pixel_values"]
+        pixel_values_array = jax.numpy.array(pixel_values)
+        vit_output = self.pjit_model_fn(pixel_values_array, self.model_params)
+        vit_output: FlaxSequenceClassifierOutput
+        vit_prediction: int = jax.numpy.argmax(vit_output.logits).item()
+
+        label = self.labels.get(vit_prediction, "")
+        return vit_prediction, label
+
+
+def load_saved_model(hugging_face_model_name) -> ViTPipeline:
+    with Progress(*Progress.get_default_columns(), TimeElapsedColumn()) as progress:
+        load_params_progress_bar = progress.add_task("Loading weights")
+        pipeline = ViTPipeline(hugging_face_model_name)
+        progress.update(load_params_progress_bar, total=1, completed=1)
+
+        # Pre-compile pjit model to avoid delay
+        # at the first prediction request.
+        precompile_progress_bar = progress.add_task("Precompiling model")
+        example_image_array = np.zeros((256, 256))
+        example_image = Image.fromarray(example_image_array)
+        _ = pipeline.predict(example_image)
+        progress.update(precompile_progress_bar, total=1, completed=1)
+
+    return pipeline

--- a/requirements_hf_flax.txt
+++ b/requirements_hf_flax.txt
@@ -1,0 +1,6 @@
+# Important: install jaxlib as per https://github.com/google/jax#installation
+jax
+flask
+flax
+transformers
+Pillow

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+from .test_flax_vit_model import *

--- a/tests/test_flax_vit_model.py
+++ b/tests/test_flax_vit_model.py
@@ -1,0 +1,30 @@
+import unittest
+import os
+from PIL import Image
+import numpy as np
+
+from model_flax_vit import ViTPipeline, load_saved_model
+
+TEST_VIT_MODEL = os.environ.get("TEST_VIT_MODEL", "google/vit-base-patch16-224")
+
+
+class ViTPipelineTest(unittest.TestCase):
+    def setUp(self):
+        self.example_vit_pipeline = ViTPipeline(TEST_VIT_MODEL)
+
+    def test_pipeline_predict(self):
+        example_image_array = np.zeros((256, 256))
+        example_image = Image.fromarray(example_image_array)
+        example_prediction_output = self.example_vit_pipeline.predict(example_image)
+
+        self.assertIsInstance(example_prediction_output[0], int)
+        self.assertIsInstance(example_prediction_output[1], str)
+
+    def test_load_pipeline_function(self):
+        loaded_pipeline = load_saved_model(TEST_VIT_MODEL)
+        example_image_array = np.ones((256, 256))
+        example_image = Image.fromarray(example_image_array)
+        example_prediction_output = loaded_pipeline.predict(example_image)
+
+        self.assertIsInstance(example_prediction_output[0], int)
+        self.assertIsInstance(example_prediction_output[1], str)


### PR DESCRIPTION
Features:
- Seamless support for both TPUs and CUDA GPUs.  
- Seamless support for image classification using [pretrained Flax Vision Transformer (ViT) models](https://huggingface.co/models?library=jax&pipeline_tag=image-classification&sort=downloads) from the HuggingFace hub.
- Supports inputs of arbitrary dimensions.
- Minimize inference latency using automated model parallelism (JAX PJIT) across all accelerator devices (e.g., parallelism across all TPU cores on a Google TPUv3-8 VM, or across multiple GPUs on a multi-GPU machine.)

Tested on Google TPUv3-8 VM.

Launch demo server:
```bash
export HF_VIT_MODEL_NAME=google/vit-base-patch16-224 
python3 app_flax_vit.py
```

Unit test:
```bash
export TEST_VIT_MODEL=google/vit-base-patch16-224 
python3 -m unittest tests
```